### PR TITLE
Automatically determine the styles/scripts that a block plugin loads

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,6 +14,8 @@ jobs:
     outputs:
       success: ${{ steps.testRunDirectory.outputs.success }}
       error: ${{ steps.testRunDirectory.outputs.error }}
+      scripts: ${{ steps.testRunDirectory.outputs.scripts }}
+      styles: ${{ steps.testRunDirectory.outputs.styles }}
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/specs/block-directory.test.js
+++ b/specs/block-directory.test.js
@@ -132,7 +132,9 @@ describe( `Block Directory Tests`, () => {
 	it( 'Block Installed - Extract Scripts & Styles required', async ( done ) => {
 		// Page reloaded from previous test.
 		runTest( () => {
-			expect( freshScripts && freshStyles ).toBeTruthy();
+			expect( freshScripts.length ).toBeGreaterThan( 0 );
+			expect( freshStyles.length  ).toBeGreaterThan( 0 );
+
 		}, `The previous test did not load scripts/styles.` );
 
 		const loadedScripts = await getAllLoadedScripts();
@@ -140,6 +142,10 @@ describe( `Block Directory Tests`, () => {
 
 		const scriptDiff = loadedScripts.filter( x => !freshScripts.some( y => ( x.id == y.id ) ) );
 		const styleDiff  = loadedStyles.filter(  x => !freshStyles.some(  y => ( x.id == y.id ) ) );
+
+		runTest( () => {
+			expect( scriptDiff.length + styleDiff.length ).toBeGreaterThan( 0 );
+		}, `The Block tested did not load any scripts/styles.` );
 
 		core.setOutput( 'scripts', scriptDiff );
 		core.setOutput( 'styles',  styleDiff  );

--- a/specs/block-directory.test.js
+++ b/specs/block-directory.test.js
@@ -127,9 +127,14 @@ describe( `Block Directory Tests`, () => {
 			core.setOutput( 'success', true );
 			done();
 		} catch ( e ) {
-			core.setFailed( e.message );
-			core.setOutput( 'error', jsError || e.message );
+			core.setFailed( e );
+
+			// Set all of the output variables, even if not used.
+			core.setOutput( 'scripts', [] );
+			core.setOutput( 'styles',  [] );
+
 			core.setOutput( 'success', false );
+			core.setOutput( 'error', e.message );
 			done();
 		}
 	} );

--- a/specs/block-directory.test.js
+++ b/specs/block-directory.test.js
@@ -133,15 +133,16 @@ describe( `Block Directory Tests`, () => {
 			expect( freshStyles.length  ).toBeGreaterThan( 0 );
 		}, `The previous test did not load scripts/styles.` );
 
+		const blocks = await getThirdPartyBlocks();
+		runTest( () => {
+			expect( blocks.length ).toBeGreaterThan( 0 );
+		}, `Block not installed.` );
+
 		const loadedScripts = await getAllLoadedScripts();
 		const loadedStyles  = await getAllLoadedStyles();
 
 		const scriptDiff = loadedScripts.filter( x => !freshScripts.some( y => ( x.id == y.id ) ) );
 		const styleDiff  = loadedStyles.filter(  x => !freshStyles.some(  y => ( x.id == y.id ) ) );
-
-		runTest( () => {
-			expect( scriptDiff.length + styleDiff.length ).toBeGreaterThan( 0 );
-		}, `The Block tested did not load any scripts/styles.` );
 
 		core.setOutput( 'scripts', scriptDiff );
 		core.setOutput( 'styles',  styleDiff  );

--- a/specs/block-directory.test.js
+++ b/specs/block-directory.test.js
@@ -119,10 +119,8 @@ describe( `Block Directory Tests`, () => {
 			core.setOutput( 'success', true );
 			done();
 		} catch ( e ) {
-
 			core.setFailed( e.message );
-			core.setOutput( 'error', jsError || e.message );
-
+			core.setOutput( 'error', e.message );
 			core.setOutput( 'success', false );
 
 			done();

--- a/specs/block-directory.test.js
+++ b/specs/block-directory.test.js
@@ -119,12 +119,9 @@ describe( `Block Directory Tests`, () => {
 			core.setOutput( 'success', true );
 			done();
 		} catch ( e ) {
-
 			core.setFailed( e.message );
 			core.setOutput( 'error', jsError || e.message );
-
 			core.setOutput( 'success', false );
-
 			done();
 		}
 	} );

--- a/specs/block-directory.test.js
+++ b/specs/block-directory.test.js
@@ -119,8 +119,10 @@ describe( `Block Directory Tests`, () => {
 			core.setOutput( 'success', true );
 			done();
 		} catch ( e ) {
+
 			core.setFailed( e.message );
-			core.setOutput( 'error', e.message );
+			core.setOutput( 'error', jsError || e.message );
+
 			core.setOutput( 'success', false );
 
 			done();

--- a/specs/block-directory.test.js
+++ b/specs/block-directory.test.js
@@ -60,8 +60,8 @@ describe( `Block Directory Tests`, () => {
 		await uninstallPlugin( pluginSlug );
 	} );
 
-	let freshScripts = false;
-	let freshStyles  = false;
+	let freshScripts = [];
+	let freshStyles  = [];
 
 	it( 'Block returns from API and installs', async ( done ) => {
 		try {
@@ -132,7 +132,6 @@ describe( `Block Directory Tests`, () => {
 		runTest( () => {
 			expect( freshScripts.length ).toBeGreaterThan( 0 );
 			expect( freshStyles.length  ).toBeGreaterThan( 0 );
-
 		}, `The previous test did not load scripts/styles.` );
 
 		const loadedScripts = await getAllLoadedScripts();

--- a/utils.js
+++ b/utils.js
@@ -32,3 +32,35 @@ export const runTest = ( func, errorMessage ) => {
 		throw new Error( errorMessage );
 	}
 };
+
+export const getAllLoadedScripts = async() => {
+	return await page.evaluate( () => {
+		let assets = [];
+		document.querySelectorAll('script').forEach( ( item ) => {
+			if ( item.src ) {
+				assets.push( {
+					'id': item.id,
+					'src': item.src.replace( /^http:\/\/[^/]+\/(wp-content\/plugins\/[^/]+\/)?/, '' ),
+				} );
+			}
+		} );
+
+		return assets;
+	} );
+};
+
+export const getAllLoadedStyles = async() => {
+	return await page.evaluate( () => {
+		let assets = [];
+		document.querySelectorAll('link[rel="stylesheet"]').forEach( ( item ) => {
+			if ( item.href ) {
+				assets.push( {
+					'id': item.id.replace( /-css$/, '' ),
+					'src': item.href.replace( /^http:\/\/[^/]+\/(wp-content\/plugins\/[^/]+\/)?/, '' ),
+				} );
+			}
+		} );
+
+		return assets;
+	} );
+};

--- a/utils.js
+++ b/utils.js
@@ -39,7 +39,7 @@ export const getAllLoadedScripts = async() => {
 		document.querySelectorAll('script').forEach( ( item ) => {
 			if ( item.src ) {
 				assets.push( {
-					'id': item.id,
+					'id': item.id.replace( /-js$/, '' ),
 					'src': item.src.replace( /^http:\/\/[^/]+\/(wp-content\/plugins\/[^/]+\/)?/, '' ),
 				} );
 			}

--- a/utils.js
+++ b/utils.js
@@ -40,7 +40,9 @@ export const getAllLoadedScripts = async() => {
 			if ( item.src ) {
 				assets.push( {
 					'id': item.id.replace( /-js$/, '' ),
-					'src': item.src.replace( /^http:\/\/[^/]+\/(wp-content\/plugins\/[^/]+\/)?/, '' ),
+					'src': item.src
+						.replace( /^http:\/\/[^/]+\/(wp-content\/plugins\/[^/]+\/)?/, '' )
+						.replace( /[?&]ver=[a-z0-9.-]+/, '' ),
 				} );
 			}
 		} );
@@ -56,7 +58,9 @@ export const getAllLoadedStyles = async() => {
 			if ( item.href ) {
 				assets.push( {
 					'id': item.id.replace( /-css$/, '' ),
-					'src': item.href.replace( /^http:\/\/[^/]+\/(wp-content\/plugins\/[^/]+\/)?/, '' ),
+					'src': item.href
+						.replace( /^http:\/\/[^/]+\/(wp-content\/plugins\/[^/]+\/)?/, '' )
+						.replace( /[?&]ver=[a-z0-9.-]+/, '' ),
 				} );
 			}
 		} );


### PR DESCRIPTION
This PR determines the scripts/styles loaded by a block plugin, by diffing the loaded scripts/styles pre/post install with a page reload in between.

This only works if the Block installs and doesn't cause a JS error, which is a problem with some plugins that this would actually help fix..

Example:
```
::set-output name=scripts::[{"id":"p5js-cgb-block-js","src":"dist/blocks.build.js?ver=1"}]
::set-output name=styles::[{"id":"p5js-cgb-block-editor","src":"dist/blocks.editor.build.css?ver=5.5-beta2-48491"},{"id":"p5js-cgb-style-css","src":"dist/blocks.style.build.css?ver=5.5-beta2-48491"}]
::set-output name=success::true
```

If a plugin were to require a core JS asset, it would be something like this:
```
::set-output name=scripts::[{"id":"core-js-handle","src":"wp-includes/js/....."},{...plugin assets...}]
```