### PR TITLE
Capture JS parse errors post-block-install

### DIFF
--- a/specs/block-directory.test.js
+++ b/specs/block-directory.test.js
@@ -51,6 +51,8 @@ Running Tests for "${ searchTerm }"
 
 describe( `Block Directory Tests`, () => {
 	beforeEach( async () => {
+		jsError = false;
+
 		await createNewPost();
 		await removeAllBlocks();
 	} );

--- a/specs/block-directory.test.js
+++ b/specs/block-directory.test.js
@@ -37,6 +37,12 @@ const urlMatch = ( url ) => {
 
 const { searchTerm } = github.context.payload.client_payload;
 
+// Variable to hold any encounted JS errors.
+let jsError = false;
+page.on( 'pageerror', error => {
+	jsError = error.toString();
+} );
+
 core.info( `
 --------------------------------------------------------------
 Running Tests for "${ searchTerm }"
@@ -93,8 +99,9 @@ describe( `Block Directory Tests`, () => {
 			core.setOutput( 'success', true );
 			done();
 		} catch ( e ) {
-			core.setFailed( e );
-			core.setOutput( 'error', e.message );
+
+			core.setFailed( e.message );
+			core.setOutput( 'error', jsError || e.message );
 			core.setOutput( 'success', false );
 			done();
 		}


### PR DESCRIPTION
This PR attempts to capture JS parse errors that stop execution.

Example output:
```
::error::Protocol error (Runtime.callFunctionOn): Session closed. Most likely the page has been closed.
::set-output name=error::Error: TypeError: Cannot read property 'renderPreview' of undefined%0A    at U (https://ps.w.org/waves/tags/1.0.0/index.js?v=1591313280:6:4319)%0A    at https://ps.w.org/waves/tags/1.0.0/index.js?v=1591313280:6:4564%0A    at commitHookEffectList (http://localhost:8889/wp-includes/js/dist/vendor/react-dom.js?ver=16.9.0:20124:26)%0A    at commitPassiveHookEffects (http://localhost:8889/wp-includes/js/dist/vendor/react-dom.js?ver=16.9.0:20154:11)%0A    at HTMLUnknownElement.callCallback (http://localhost:8889/wp-includes/js/dist/vendor/react-dom.js?ver=16.9.0:341:14)%0A    at Object.invokeGuardedCallbackDev (http://localhost:8889/wp-includes/js/dist/vendor/react-dom.js?ver=16.9.0:391:16)%0A    at invokeGuardedCallback (http://localhost:8889/wp-includes/js/dist/vendor/react-dom.js?ver=16.9.0:448:31)%0A    at flushPassiveEffectsImpl (http://localhost:8889/wp-includes/js/dist/vendor/react-dom.js?ver=16.9.0:23006:7)%0A    at unstable_runWithPriority (http://localhost:8889/wp-includes/js/dist/vendor/react.js?ver=16.9.0:2820:12)%0A    at runWithPriority$2 (http://localhost:8889/wp-includes/js/dist/vendor/react-dom.js?ver=16.9.0:11443:10)
::set-output name=success::false
```

Unfortunately this still kills the execution of the tests, so #1 still won't be able to get the data it needs.