### PR TITLE
Add the ability to pass a search term.

### DIFF
--- a/specs/block-directory.test.js
+++ b/specs/block-directory.test.js
@@ -35,7 +35,7 @@ const urlMatch = ( url ) => {
 	return url.indexOf( urlPart ) >= 0 || url.indexOf( encoded ) >= 0;
 };
 
-const { searchTerm } = github.context.payload.client_payload;
+const searchTerm =  process.env.SEARCH_TERM || github.context.payload.client_payload.searchTerm;
 
 core.info( `
 --------------------------------------------------------------


### PR DESCRIPTION
Support `SEARCH_TERM` as an environment variable for local testing.

"SEARCH_TERM={string} npm run test:e2e`